### PR TITLE
Spinner bubbles up `tea.Program` errors

### DIFF
--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -151,9 +151,9 @@ func (s *Spinner) Run() error {
 		}()
 	}
 
-	_, _ = p.Run()
+	_, err = p.Run()
 
-	return nil
+	return err
 }
 
 // runAccessible runs the spinner in an accessible mode (statically).


### PR DESCRIPTION
When running the `tea.Program` backing the spinner generates an error then bubble it up to the user.

Got bitten by this when a user of our CLI tried running it via `ssh`. The underlying `tea.Program` was complaining about not having a TTY, but our application wasn't able to access the `error`.